### PR TITLE
ensure that when an exception occurs, it will print console logs

### DIFF
--- a/boot.go
+++ b/boot.go
@@ -254,7 +254,8 @@ func (boot *Boot) readYAML() []byte {
 func syncLog(eventId string) {
 	if r := recover(); r != nil {
 		stackTrace := fmt.Sprintf("Panic occured, shutting down... \n%s", string(debug.Stack()))
-		for _, v := range rkentry.GlobalAppCtx.ListEntriesByType(rkentry.LoggerEntryType) {
+		logEntries := rkentry.GlobalAppCtx.ListEntriesByType(rkentry.LoggerEntryType)
+		for _, v := range logEntries {
 			logger, ok := v.(*rkentry.LoggerEntry)
 			if !ok {
 				continue
@@ -266,6 +267,11 @@ func syncLog(eventId string) {
 					zap.Any("RootCause", r))
 			}
 			logger.Sync()
+		}
+
+		if len(logEntries) == 0 {
+			fmt.Printf(stackTrace)
+			fmt.Printf("RootCause: %s", r)
 		}
 
 		for _, v := range rkentry.GlobalAppCtx.ListEntriesByType(rkentry.EventEntryType) {


### PR DESCRIPTION
日志系统没有初始化的时候，是无法打印日志的。在类似集群里很难判断错误